### PR TITLE
fix: use the latest method name

### DIFF
--- a/lua/cmp_skkeleton/init.lua
+++ b/lua/cmp_skkeleton/init.lua
@@ -39,7 +39,7 @@ end
 ---@param params cmp.SourceCompletionApiParams
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
-  local candidates = request("getCandidates")
+  local candidates = request("getCompletionResult")
   local pre_edit = request("getPreEdit")
   local pre_edit_len = request("getPreEditLength")
   local ranks = request("getRanks")


### PR DESCRIPTION
Now skkeleton uses `getCompletionResult` as the method name.

See https://github.com/vim-skk/skkeleton/commit/13d75582bf440f4f336323f14e801774b056f3a7